### PR TITLE
devstack hardcodes 127.0.0.1 for mysql :-(

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -10,7 +10,7 @@ mysql:
   server:
     root_password: {{ site.devstack_password }}
     mysqld:
-      bind_address: {{ site.host_ipv4 or site.host_ipv6 }}
+      bind_address: {{ site.db_host or site.host_ipv4 or site.host_ipv6 }}
 
 etcd:
   service:
@@ -319,29 +319,29 @@ packages:
           source: {{ site.kubectl_url }}
           hashsum: {{ site.kubectl_hashsum }}
       opensds-hotpot:
-        dest: /tmp/opt/opensds-linux-amd64
+        dest: /opt/opensds-linux-amd64
         options: '--strip-components=1'
         dl:
           format: tar
           source: {{ site.hotpot_uri }}/{{ site.hotpot_release }}/opensds-hotpot-{{ site.hotpot_release }}-linux-amd64.tar.gz
           hashsum: {{ site.hotpot_hashsum }}
       opensds-sushi:
-        dest: /tmp/usr/local/go/bin/src/github.com/opensds/nbp
+        dest: /usr/local/go/bin/src/github.com/opensds/nbp
         options: '--strip-components=1'
         dl:
           format: tar
           source: {{ site.sushi_uri }}/{{ site.sushi_release }}/opensds-sushi-{{ site.sushi_release }}-linux-amd64.tar.gz
           hashsum: {{ site.sushi_hashsum }}
       cinder:
-        dest: /tmp/opt/opensds-k8s-linux-amd64/cinder
+        dest: /opt/opensds-k8s-linux-amd64/cinder
         dl:
           format: yml
           source: {{ site.cinder_url }}
           hashsum: {{ site.cinder_hashsum }}
     unwanted:
-      - /tmp/usr/local/go/bin/src/github.com/opensds/nbp
-      - /tmp/opt/opensds-k8s-linux-amd64
-      - /tmp/opt/opensds-linux-amd64
+      - /usr/local/go/bin/src/github.com/opensds/nbp
+      - /opt/opensds-k8s-linux-amd64
+      - /opt/opensds-linux-amd64
       # /var/lib/mysql/
 
 salt:
@@ -390,6 +390,7 @@ salt_formulas:
      - deepsea-formula
      - docker-formula
      - etcd-formula
+     - firewalld-formula
      - helm-formula
      - iscsi-formula
      - lvm-formula

--- a/site.j2
+++ b/site.j2
@@ -36,6 +36,7 @@
 
       'host_ipv4': grains.ipv4[-1],
       'host_ipv6': grains.ipv6[-1],
+      'db_host': '127.0.0.1',
       'port_controller': '50040',
       'port_dock': '50050',
 }) %}


### PR DESCRIPTION
Workaround upstream [limitation](https://bugs.launchpad.net/devstack/+bug/1735097) where 127.0.0.1 is hardcoded in /opt/stack/lib/databases/mysql.  

Also fix dest vars in pillar.example