### PR TITLE
Fix file.managed.replace warnings & container versions

### DIFF
--- a/opensds/auth/defaults.yaml
+++ b/opensds/auth/defaults.yaml
@@ -11,6 +11,7 @@ opensds:
       composed: False
       build: False
       image: None
+      version: latest
     opensdsconf:
       keystone_authtoken:
         memcached_servers: {{ grains.ipv4[-1] or grains.ipv6[-1] }}:11211

--- a/opensds/auth/init.sls
+++ b/opensds/auth/init.sls
@@ -15,7 +15,7 @@ include:
 opensds auth container service running:
   docker_container.running:
     - name: {{ opensds.auth.service }}
-    - image: {{ opensds.auth.container.image }}
+    - image: {{ opensds.auth.container.image }}:{{ opensds.auth.container.version }}
     - restart_policy: always
     - network_mode: host
          {%- if "volumes" in opensds.auth.container %}

--- a/opensds/controller/defaults.yaml
+++ b/opensds/controller/defaults.yaml
@@ -12,7 +12,8 @@ opensds:
       enabled: False
       composed: False
       build: False
-      image: opensdsio/opensds-controller:aruba
+      image: opensdsio/opensds-controller
+      version: latest
       ports:
         - {{ grains.ipv4[-1] or grains.ipv6[-1] }}:50040:50040
       volumes:

--- a/opensds/controller/init.sls
+++ b/opensds/controller/init.sls
@@ -15,7 +15,7 @@ include:
 opensds controller container service running:
   docker_container.running:
     - name: {{ opensds.controller.service }}
-    - image: {{ opensds.controller.container.image }}
+    - image: {{opensds.controller.container.image}}:{{opensds.controller.container.version}}
     - restart_policy: always
     - network_mode: host
           {%- if "volumes" in opensds.controller.container %}

--- a/opensds/dashboard/defaults.yaml
+++ b/opensds/dashboard/defaults.yaml
@@ -9,7 +9,8 @@ opensds:
       enabled: True
       composed: False
       build: False
-      image: opensdsio/dashboard:latest
+      image: opensdsio/dashboard
+      version: latest
     repo:
       url: https://github.com/opensds/opensds.git
       branch: development

--- a/opensds/dashboard/init.sls
+++ b/opensds/dashboard/init.sls
@@ -15,7 +15,7 @@ include:
 opensds dashboard container service running:
   docker_container.running:
     - name: {{ opensds.dashboard.service }}
-    - image: {{ opensds.dashboard.container.image }}
+    - image: {{ opensds.dashboard.container.image }}:{{ opensds.dashboard.container.version}}
     - restart_policy: always
     - network_mode: host
          {%- if "volumes" in opensds.dashboard.container %}

--- a/opensds/database/defaults.yaml
+++ b/opensds/database/defaults.yaml
@@ -8,7 +8,9 @@ opensds:
     container:
       enabled: True
       composed: False
-      build: True
+      build: True   {# we will use etcd.docker.running state instead of this #}
+      image: None
+      version: latest
     opensdsconf:
       database:
         db_driver: etcd

--- a/opensds/database/init.sls
+++ b/opensds/database/init.sls
@@ -19,7 +19,7 @@ include:
 opensds database container service running:
   database_container.running:
     - name: {{ opensds.database.service }}
-    - image: {{ opensds.database.container.image }}
+    - image: {{ opensds.database.container.image }}:{{ opensds.database.container.version }}
     - restart_policy: always
     - network_mode: host
            {%- if "volumes" in opensds.database.container %}

--- a/opensds/dock/block/ceph/init.sls
+++ b/opensds/dock/block/ceph/init.sls
@@ -15,7 +15,7 @@ include:
 opensds dock block ceph container running:
   docker_container.running:
     - name: {{ opensds.dock.block.ceph.service }}
-    - image: {{ opensds.dock.block.ceph.container.image }}
+    - image: {{opensds.dock.block.ceph.container.image}}:{{opensds.dock.block.ceph.container.version}}
     - restart_policy: always
     - network_mode: host
          {%- if "volumes" in opensds.dock.block.ceph.container %}

--- a/opensds/dock/block/cinder/init.sls
+++ b/opensds/dock/block/cinder/init.sls
@@ -39,7 +39,7 @@ opensds dock block cinder loci build from source:
 opensds dock block cinder container running:
   docker_container.running:
     - name: {{ opensds.dock.block.cinder.service }}
-    - image: {{ opensds.dock.block.cinder.container.image }}
+    - image: {{opensds.dock.block.cinder.container.image}}:{{opensds.dock.block.cinder.container.version}}
     - restart_policy: always
     - network_mode: host
          {%- if "volumes" in opensds.dock.block.cinder.container %}

--- a/opensds/dock/block/defaults.yaml
+++ b/opensds/dock/block/defaults.yaml
@@ -12,12 +12,15 @@ opensds:
         composed: True
         build: False
         image: None
+        version: latest
       cinder:
         opensdsconf: {}
         container:
           enabled: True
           composed: False
           build: True
+          image: None
+          version: latest
       ceph:
         opensdsconf: {}
         container:
@@ -25,6 +28,7 @@ opensds:
           composed: False
           build: False
           image: None
+          version: latest
       lvm:
         opensdsconf: {}
         container:

--- a/opensds/dock/block/init.sls
+++ b/opensds/dock/block/init.sls
@@ -15,7 +15,7 @@ include:
 opensds dock block {{ opensds.dock.block.provider }} container running:
   docker_container.running:
     - name: {{ opensds.dock.block.service }}
-    - image: {{ opensds.dock.block.container.image }}
+    - image: {{opensds.dock.block.container.image}}:{{opensds.dock.block.container.version}}
     - restart_policy: always
     - network_mode: host
          {%- if "volumes" in opensds.dock.block.container %}

--- a/opensds/dock/block/lvm/init.sls
+++ b/opensds/dock/block/lvm/init.sls
@@ -14,7 +14,7 @@ include:
 opensds dock block lvm container running:
   docker_container.running:
     - name: {{ opensds.dock.block.lvm.service }}
-    - image: {{ opensds.dock.block.lvm.container.image }}
+    - image: {{opensds.dock.block.lvm.container.image}}:{{opensds.dock.block.lvm.container.version}}
     - restart_policy: always
     - network_mode: host
          {%- if "volumes" in opensds.dock.block.lvm.container %}

--- a/opensds/dock/defaults.yaml
+++ b/opensds/dock/defaults.yaml
@@ -9,7 +9,8 @@ opensds:
       enabled: True
       composed: False
       build: False
-      image: opensdsio/opensds-dock:latest
+      image: opensdsio/opensds-dock
+      version: latest
       volumes:
         - /etc/opensds/:/etc/opensds
         - /etc/ceph/:/etc/ceph

--- a/opensds/dock/init.sls
+++ b/opensds/dock/init.sls
@@ -15,7 +15,7 @@ include:
 opensds dock container service running:
   docker_container.running:
     - name: {{ opensds.dock.service }}
-    - image: {{ opensds.dock.container.image }}
+    - image: {{ opensds.dock.container.image }}:{{ opensds.dock.container.version }}
     - restart_policy: always
     - network_mode: host
           {%- if "volumes" in opensds.dock.container %}
@@ -62,6 +62,7 @@ opensds dock ensure opensds config file exists:
     - makedirs: True
     - user: {{ opensds.user or 'root' }}
     - mode: {{ opensds.file_mode or '0644' }}
+    - replace: False
 
        {% for section, data in opensds.dock.opensdsconf.items() %}
 

--- a/opensds/let/defaults.yaml
+++ b/opensds/let/defaults.yaml
@@ -9,6 +9,7 @@ opensds:
       composed: False
       build: False
       image: None
+      version: latest
     opensdsconf:
       osdslet:
         api_endpoint: '{{ grains.ipv4[-1] or grains.ipv6[-1] }}:50040'

--- a/opensds/let/init.sls
+++ b/opensds/let/init.sls
@@ -15,7 +15,7 @@ include:
 opensds let {{ opensds.controller.release }} container service running:
   docker_container.running:
     - name: {{ opensds.let.service }}
-    - image: {{ opensds.let.container.image }}
+    - image: {{ opensds.let.container.image }}:{{ opensds.let.container.version }}
     - restart_policy: always
     - network_mode: host
          {%- if "volumes" in opensds.let.container %}

--- a/opensds/nbp/defaults.yaml
+++ b/opensds/nbp/defaults.yaml
@@ -16,12 +16,14 @@ opensds:
       composed: False
       build: False
       image: None
+      version: latest
     plugins:
       container:
         enabled: False
         composed: False
         build: False
         image: None
+        version: latest
       csi:
         dir: /opt/opensds-sushi-linux-amd64/csi/deploy/kubernetes
         conf: csi-k8s_configmap-opensdsplugin.yaml

--- a/opensds/nbp/init.sls
+++ b/opensds/nbp/init.sls
@@ -15,7 +15,7 @@ include:
 opensds nbp container service running:
   docker_container.running:
     - name: {{ opensds.nbp.service }}
-    - image: {{ opensds.nbp.container.image }}
+    - image: {{ opensds.nbp.container.image }}:{{ opensds.nbp.container.version }}
     - restart_policy: always
     - network_mode: host
            {%- if "volumes" in opensds.nbp.container %}

--- a/opensds/nbp/plugins/init.sls
+++ b/opensds/nbp/plugins/init.sls
@@ -16,7 +16,7 @@ include:
 opensds nbp plugins container service running:
   docker_container.running:
     - name: {{ opensds.nbp.plugins.service }}
-    - image: {{ opensds.nbp.plugins.container.image }}
+    - image: {{opensds.nbp.plugins.container.image}}:{{opensds.nbp.plugins.container.version}}
     - restart_policy: always
     - network_mode: host
            {%- if "volumes" in opensds.nbp.plugins.container %}
@@ -82,6 +82,7 @@ opensds nbp plugins ensure opensds k8s {{ plugin }} plugin file exists:
     - makedirs: True
     - user: {{ opensds.user or 'root' }}
     - mode: {{ opensds.file_mode or '0644' }}
+    - replace: False
 
 opensds nbp ensure correct endpoint in opensds k8s {{ plugin }} plugin:
   file.replace:

--- a/pillar.example
+++ b/pillar.example
@@ -16,6 +16,8 @@ etcd:
   #service:
     #etcd_endpoints: https://{{ site.host_ipv4 or site.host_ipv6 }}:2379,https://{{ site.host_ipv4 or site.host_ipv6 }}:2380
   docker:
+    image: {{ site.img_etcd }}
+    version: {{ site.ver_etcd }}
     container_name: osdsdb-etcd
     enabled: True
     skip_translate: None
@@ -69,12 +71,14 @@ opensds:
     container:
       enabled: False    #or True
       image: {{ site.img_controller }}
+      version: {{ site.ver_controller }}
       ports:
         - {{ site.host_ipv4 or site.host_ipv6 }}:{{ site.port_controller }}:{{ site.port_controller }}
   dashboard:
     provider: repo       #or release
     container:
       image: {{ site.img_dashboard }}
+      version: {{ site.ver_dashboard }}
   nbp:
     provider: release  #or repo
     plugin_type: {{ site.dock_type }}
@@ -91,6 +95,7 @@ opensds:
   dock:
     container:
       image: {{ site.img_dock }}
+      version: {{ site.ver_dock }}
       volumes:
         - /etc/opensds/:/etc/opensds
     opensdsconf:
@@ -238,6 +243,7 @@ docker:
   compose:
     controller:
       image: {{ site.img_controller }}
+      version: {{ site.ver_controller }}
       container_name: opensds-controller
       network_mode: host
       ports:
@@ -253,6 +259,7 @@ docker:
           window: 120s
     dock:
       image: {{ site.img_dock }}
+      version: {{ site.ver_dock }}
       container_name: osdsdock
       privileged: True
       network_mode: host
@@ -267,6 +274,7 @@ docker:
           window: 120s
     dashboard:
       image: {{ site.img_dashboard }}
+      version: {{ site.ver_dashboard }}
       container_name: dashboard
       privileged: True
       network_mode: host

--- a/pillar.example
+++ b/pillar.example
@@ -15,6 +15,8 @@ mysql:
 etcd:
   #service:
     #etcd_endpoints: https://{{ site.host_ipv4 or site.host_ipv6 }}:2379,https://{{ site.host_ipv4 or site.host_ipv6 }}:2380
+  dir:
+    tmp: /tmp/devstack  {# not sure why centos wants this here? #}
   docker:
     image: {{ site.img_etcd }}
     version: {{ site.ver_etcd }}

--- a/site.j2
+++ b/site.j2
@@ -25,10 +25,15 @@
       'enabled_backend': 'lvm',
       'poolname': 'opensds-volumes',
 
-      'img_controller': 'opensdsio/opensds-controller:latest',
-      'img_dock': 'opensdsio/opensds-dock:latest',
-      'img_dashboard': 'opensdsio/dashboard:latest',
-      'img_etcd': 'quay.io/coreos/etcd:latest',
+      'img_controller': 'opensdsio/opensds-controller',
+      'img_dock': 'opensdsio/opensds-dock',
+      'img_dashboard': 'opensdsio/dashboard',
+      'img_etcd': 'quay.io/coreos/etcd',
+
+      'ver_controller': 'latest',
+      'ver_dock': 'latest',
+      'ver_dashboard': 'latest',
+      'ver_etcd': 'latest',
 
       'devstack_enabled_services': 'mysql,key',
       'devstack_password': 'opensds@123',


### PR DESCRIPTION
This PR has two purposes.

(1) Resolve some `file.managed` warnings when source is None.
```
[WARNING ] State for file: /opt/opensds-sushi-linux-amd64/provisioner/deploy/kubernetes/configmap.yaml - Neither 'source' nor 'contents' nor 'contents_pillar' nor 'contents_grains' was defined, yet 'replace' was set to 'True'. As there is no source to replace the file with, 'replace' has been set to 'False' to avoid reading the file unnecessarily.
[WARNING ] State for file: /etc/opensds/opensds.conf - Neither 'source' nor 'contents' nor 'contents_pillar' nor 'contents_grains' was defined, yet 'replace' was set to 'True'. As there is no source to replace the file with, 'replace' has been set to 'False' to avoid reading the file unnecessarily.
```
(2) Allow Docker container versions to be pillar values.
