### PR TITLE
Set salt warnings and inject correct hostname

### DIFF
--- a/opensds/auth/defaults.yaml
+++ b/opensds/auth/defaults.yaml
@@ -5,7 +5,7 @@ opensds:
   auth:
     service: osdsauth
     provider: keystone
-    endpoint: http://{{ grains.ipv4[-1] or grains.ipv6[-1] }}:50040
+    endpoint: http://{{ grains.ipv4[1] or grains.ipv6[1] }}:50040
     container:
       enabled: False
       composed: False
@@ -14,9 +14,9 @@ opensds:
       version: latest
     opensdsconf:
       keystone_authtoken:
-        memcached_servers: {{ grains.ipv4[-1] or grains.ipv6[-1] }}:11211
+        memcached_servers: {{ grains.ipv4[1] or grains.ipv6[1] }}:11211
         project_domain_name: Default
         project_name: service
         user_domain_name: Default
-        auth_url: http://{{ grains.ipv4[-1] or grains.ipv6[-1] }}/identity
+        auth_url: http://{{ grains.ipv4[1] or grains.ipv6[1] }}/identity
         auth_type: password

--- a/opensds/auth/defaults.yaml
+++ b/opensds/auth/defaults.yaml
@@ -5,7 +5,7 @@ opensds:
   auth:
     service: osdsauth
     provider: keystone
-    endpoint: http://{{ grains.ipv4[1] or grains.ipv6[1] }}:50040
+    endpoint: http://{{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}:50040
     container:
       enabled: False
       composed: False
@@ -14,9 +14,9 @@ opensds:
       version: latest
     opensdsconf:
       keystone_authtoken:
-        memcached_servers: {{ grains.ipv4[1] or grains.ipv6[1] }}:11211
+        memcached_servers: {{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1'}}:11211
         project_domain_name: Default
         project_name: service
         user_domain_name: Default
-        auth_url: http://{{ grains.ipv4[1] or grains.ipv6[1] }}/identity
+        auth_url: http://{{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}/identity
         auth_type: password

--- a/opensds/auth/defaults.yaml
+++ b/opensds/auth/defaults.yaml
@@ -5,7 +5,7 @@ opensds:
   auth:
     service: osdsauth
     provider: keystone
-    endpoint: http://{{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}:50040
+    endpoint: http://{{ grains.ipv4[-1] or grains.ipv6[-1] or '127.0.0.1' }}:50040
     container:
       enabled: False
       composed: False
@@ -14,9 +14,9 @@ opensds:
       version: latest
     opensdsconf:
       keystone_authtoken:
-        memcached_servers: {{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1'}}:11211
+        memcached_servers: {{ grains.ipv4[-1] or grains.ipv6[-1] or '127.0.0.1'}}:11211
         project_domain_name: Default
         project_name: service
         user_domain_name: Default
-        auth_url: http://{{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}/identity
+        auth_url: http://{{ grains.ipv4[-1] or grains.ipv6[-1] or '127.0.0.1' }}/identity
         auth_type: password

--- a/opensds/auth/init.sls
+++ b/opensds/auth/init.sls
@@ -65,6 +65,7 @@ opensds auth ensure opensds config file exists:
     - makedirs: True
     - user: {{ opensds.user or 'root' }}
     - mode: {{ opensds.file_mode or '0644' }}
+    - replace: False
 
     {% for section, data in opensds.auth.opensdsconf.items() %}
 

--- a/opensds/controller/defaults.yaml
+++ b/opensds/controller/defaults.yaml
@@ -3,7 +3,7 @@
 #
 opensds:
   controller:
-    endpoint: http://{{ grains.ipv4[1] or grains.ipv6[1] }}:50040
+    endpoint: http://{{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}:50040
     provider: release    #release or repo
     repo:
       url: https://github.com/opensds/opensds.git
@@ -15,6 +15,6 @@ opensds:
       image: opensdsio/opensds-controller
       version: latest
       ports:
-        - {{ grains.ipv4[1] or grains.ipv6[1] }}:50040:50040
+        - {{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}:50040:50040
       volumes:
         - /etc/opensds/:/etc/opensds

--- a/opensds/controller/defaults.yaml
+++ b/opensds/controller/defaults.yaml
@@ -9,7 +9,7 @@ opensds:
       url: https://github.com/opensds/opensds.git
       branch: development
     container:
-      enabled: False
+      enabled: True
       composed: False
       build: False
       image: opensdsio/opensds-controller

--- a/opensds/controller/defaults.yaml
+++ b/opensds/controller/defaults.yaml
@@ -3,7 +3,7 @@
 #
 opensds:
   controller:
-    endpoint: http://{{ grains.ipv4[-1] or grains.ipv6[-1] }}:50040
+    endpoint: http://{{ grains.ipv4[1] or grains.ipv6[1] }}:50040
     provider: release    #release or repo
     repo:
       url: https://github.com/opensds/opensds.git
@@ -15,6 +15,6 @@ opensds:
       image: opensdsio/opensds-controller
       version: latest
       ports:
-        - {{ grains.ipv4[-1] or grains.ipv6[-1] }}:50040:50040
+        - {{ grains.ipv4[1] or grains.ipv6[1] }}:50040:50040
       volumes:
         - /etc/opensds/:/etc/opensds

--- a/opensds/controller/defaults.yaml
+++ b/opensds/controller/defaults.yaml
@@ -3,7 +3,7 @@
 #
 opensds:
   controller:
-    endpoint: http://{{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}:50040
+    endpoint: http://{{ grains.ipv4[-1] or grains.ipv6[-1] or '127.0.0.1' }}:50040
     provider: release    #release or repo
     repo:
       url: https://github.com/opensds/opensds.git
@@ -15,6 +15,6 @@ opensds:
       image: opensdsio/opensds-controller
       version: latest
       ports:
-        - {{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}:50040:50040
+        - {{ grains.ipv4[-1] or grains.ipv6[-1] or '127.0.0.1' }}:50040:50040
       volumes:
         - /etc/opensds/:/etc/opensds

--- a/opensds/dashboard/init.sls
+++ b/opensds/dashboard/init.sls
@@ -65,6 +65,7 @@ opensds dashboard ensure opensds config file exists:
     - makedirs: True
     - user: {{ opensds.user or 'root' }}
     - mode: {{ opensds.file_mode or '0644' }}
+    - replace: False
 
         {% for section, data in opensds.dashboard.opensdsconf.items() %}
 

--- a/opensds/database/defaults.yaml
+++ b/opensds/database/defaults.yaml
@@ -14,12 +14,12 @@ opensds:
     opensdsconf:
       database:
         db_driver: etcd
-        db_endpoint: https://{{grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}:2379,https://{{grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}:2380
+        db_endpoint: https://{{grains.ipv4[-1] or grains.ipv6[-1] or '127.0.0.1' }}:2379,https://{{grains.ipv4[-1] or grains.ipv6[-1] or '127.0.0.1' }}:2380
 
 etcd:
   service:
     name: osdsdb
-    etcd_endpoints: https://{{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1'  }}:2379,https://{{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}:2380
+    etcd_endpoints: https://{{ grains.ipv4[-1] or grains.ipv6[-1] or '127.0.0.1'  }}:2379,https://{{ grains.ipv4[-1] or grains.ipv6[-1] or '127.0.0.1' }}:2380
   docker:
     enabled: True
 

--- a/opensds/database/defaults.yaml
+++ b/opensds/database/defaults.yaml
@@ -14,12 +14,12 @@ opensds:
     opensdsconf:
       database:
         db_driver: etcd
-        db_endpoint: https://{{grains.ipv4[-1] or grains.ipv6[-1]}}:2379,https://{{grains.ipv4[-1] or grains.ipv6[-1]}}:2380
+        db_endpoint: https://{{grains.ipv4[1] or grains.ipv6[1]}}:2379,https://{{grains.ipv4[1] or grains.ipv6[1]}}:2380
 
 etcd:
   service:
     name: osdsdb
-    etcd_endpoints: https://{{ grains.ipv4[-1] or grains.ipv6[-1] }}:2379,https://{{ grains.ipv4[-1] or grains.ipv6[-1] }}:2380
+    etcd_endpoints: https://{{ grains.ipv4[1] or grains.ipv6[1] }}:2379,https://{{ grains.ipv4[1] or grains.ipv6[1] }}:2380
   docker:
     enabled: True
 

--- a/opensds/database/defaults.yaml
+++ b/opensds/database/defaults.yaml
@@ -14,12 +14,12 @@ opensds:
     opensdsconf:
       database:
         db_driver: etcd
-        db_endpoint: https://{{grains.ipv4[1] or grains.ipv6[1]}}:2379,https://{{grains.ipv4[1] or grains.ipv6[1]}}:2380
+        db_endpoint: https://{{grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}:2379,https://{{grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}:2380
 
 etcd:
   service:
     name: osdsdb
-    etcd_endpoints: https://{{ grains.ipv4[1] or grains.ipv6[1] }}:2379,https://{{ grains.ipv4[1] or grains.ipv6[1] }}:2380
+    etcd_endpoints: https://{{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1'  }}:2379,https://{{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}:2380
   docker:
     enabled: True
 

--- a/opensds/database/init.sls
+++ b/opensds/database/init.sls
@@ -56,6 +56,7 @@ opensds database ensure opensds config file exists:
     - makedirs: True
     - user: {{ opensds.user or 'root' }}
     - mode: {{ opensds.file_mode or '0644' }}
+    - replace: False
 
         {% for section, data in opensds.database.opensdsconf.items() %}
 

--- a/opensds/defaults.yaml
+++ b/opensds/defaults.yaml
@@ -13,6 +13,7 @@ opensds:
   user: root
   controller:
     conf: /etc/opensds/opensds.conf
+  host: 127.0.0.1
   ports:
     opensds: '50040'
     dock: '50050'

--- a/opensds/dock/defaults.yaml
+++ b/opensds/dock/defaults.yaml
@@ -16,7 +16,7 @@ opensds:
         - /etc/ceph/:/etc/ceph
     opensdsconf:
       osdsdock:
-        api_endpoint: {{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}:50050
+        api_endpoint: {{ grains.ipv4[-1] or grains.ipv6[-1] or '127.0.0.1' }}:50050
         log_file: /var/log/opensds/osdsdock.log
         dock_type: provisioner
         enabled_backends: lvm           ## lvm, ceph, and/or cinder

--- a/opensds/dock/defaults.yaml
+++ b/opensds/dock/defaults.yaml
@@ -16,7 +16,7 @@ opensds:
         - /etc/ceph/:/etc/ceph
     opensdsconf:
       osdsdock:
-        api_endpoint: {{ grains.ipv4[-1] or grains.ipv6[-1] }}:50050
+        api_endpoint: {{ grains.ipv4[1] or grains.ipv6[1] }}:50050
         log_file: /var/log/opensds/osdsdock.log
         dock_type: provisioner
         enabled_backends: lvm           ## lvm, ceph, and/or cinder

--- a/opensds/dock/defaults.yaml
+++ b/opensds/dock/defaults.yaml
@@ -16,7 +16,7 @@ opensds:
         - /etc/ceph/:/etc/ceph
     opensdsconf:
       osdsdock:
-        api_endpoint: {{ grains.ipv4[1] or grains.ipv6[1] }}:50050
+        api_endpoint: {{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}:50050
         log_file: /var/log/opensds/osdsdock.log
         dock_type: provisioner
         enabled_backends: lvm           ## lvm, ceph, and/or cinder

--- a/opensds/let/defaults.yaml
+++ b/opensds/let/defaults.yaml
@@ -12,7 +12,7 @@ opensds:
       version: latest
     opensdsconf:
       osdslet:
-        api_endpoint: '{{ grains.ipv4[-1] or grains.ipv6[-1] }}:50040'
+        api_endpoint: '{{ grains.ipv4[1] or grains.ipv6[1] }}:50040'
         graceful: True
         log_file: /var/log/opensds/osdslet.log
         socket_order: inc

--- a/opensds/let/defaults.yaml
+++ b/opensds/let/defaults.yaml
@@ -12,7 +12,7 @@ opensds:
       version: latest
     opensdsconf:
       osdslet:
-        api_endpoint: '{{ grains.ipv4[1] or grains.ipv6[1] }}:50040'
+        api_endpoint: '{{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}:50040'
         graceful: True
         log_file: /var/log/opensds/osdslet.log
         socket_order: inc

--- a/opensds/let/defaults.yaml
+++ b/opensds/let/defaults.yaml
@@ -12,7 +12,7 @@ opensds:
       version: latest
     opensdsconf:
       osdslet:
-        api_endpoint: '{{ grains.ipv4[1] or grains.ipv6[1] or '127.0.0.1' }}:50040'
+        api_endpoint: '{{ grains.ipv4[-1] or grains.ipv6[-1] or '127.0.0.1' }}:50040'
         graceful: True
         log_file: /var/log/opensds/osdslet.log
         socket_order: inc

--- a/opensds/let/init.sls
+++ b/opensds/let/init.sls
@@ -58,6 +58,7 @@ opensds let ensure opensds config file exists:
     - makedirs: True
     - user: {{ opensds.user or 'root' }}
     - mode: {{ opensds.file_mode or '0644' }}
+    - replace: False
 
     {% for section, data in opensds.let.opensdsconf.items() %}
 

--- a/opensds/map.jinja
+++ b/opensds/map.jinja
@@ -55,3 +55,8 @@
 {% from "opensds/files/macros.jinja" import deep_merge with context %}
 {%- import_yaml 'opensds/dock/drivers/' ~ opensds.dock.block.provider ~ '.yaml' as driver %}
 {%- do deep_merge(driver, opensds.driver) %}
+
+# SITE SPECIFIC PARAM INJECTION
+{%- if opensds.dock.block.provider in ('lvm',) %}
+  {%- do driver.update({'tgtBindIp': opensds.host or '127.0.0.1'}) %}
+{%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -69,6 +69,8 @@ opensds:
     opensdsconf:
       osdslet:
         api_endpoint: {{ site.host_ipv4 or site.host_ipv6 }}:{{ site.port_controller }}
+        auth_strategy: noauth
+
   controller:
     endpoint: {{ site.host_ipv4 or site.host_ipv6 }}:{{ site.port_dock }}
     container:
@@ -244,38 +246,7 @@ docker:
     skip_translate: ports
     force_present: False
     force_running: False   #maybe unsupported by python-py
-  compose:
-    controller:
-      image: {{ site.img_controller }}
-      version: {{ site.ver_controller }}
-      container_name: opensds-controller
-      network_mode: host
-      ports:
-        - '{{ site.host_ipv4 or site.host_ipv6 }}:{{ site.port_dock }}:{{ site.port_dock }}'
-      volumes:
-        - '/etc/opensds/:/etc/opensds'
-        # '/usr/share/ca-certificates/:/etc/ssl/certs'
-      deploy:
-        restart_policy:
-          condition: on-failure
-          delay: 5s
-          max_attempts: 3
-          window: 120s
-    dock:
-      image: {{ site.img_dock }}
-      version: {{ site.ver_dock }}
-      container_name: osdsdock
-      privileged: True
-      network_mode: host
-      volumes:
-        - '/etc/opensds/:/etc/opensds'
-        - '/etc/ceph/:/etc/ceph'
-      deploy:
-        restart_policy:
-          condition: on-failure
-          delay: 5s
-          max_attempts: 3
-          window: 120s
+  compose: {}
 
 packages:
   pips:

--- a/pillar.example
+++ b/pillar.example
@@ -276,18 +276,6 @@ docker:
           delay: 5s
           max_attempts: 3
           window: 120s
-    dashboard:
-      image: {{ site.img_dashboard }}
-      version: {{ site.ver_dashboard }}
-      container_name: osdsDash
-      privileged: True
-      network_mode: host
-      deploy:
-        restart_policy:
-          condition: on-failure
-          delay: 5s
-          max_attempts: 3
-          window: 120s
 
 packages:
   pips:

--- a/pillar.example
+++ b/pillar.example
@@ -16,7 +16,7 @@ etcd:
   #service:
     #etcd_endpoints: https://{{ site.host_ipv4 or site.host_ipv6 }}:2379,https://{{ site.host_ipv4 or site.host_ipv6 }}:2380
   dir:
-    tmp: /tmp/devstack  {# not sure why centos wants this here? #}
+    tmp: /tmp/devstack
   docker:
     image: {{ site.img_etcd }}
     version: {{ site.ver_etcd }}
@@ -35,6 +35,7 @@ etcd:
 
 
 opensds:
+  host: {{ site.host_ipv4 or site.host_ipv6 }}
   ports:
     opensds: {{ site.port_controller }}
     dock: {{ site.port_dock }}
@@ -180,6 +181,7 @@ devstack:
     db_host: {{ site.db_host }}
   dir:
     dest: {{ site.devstack_dir }}
+    tmp: /tmp/devstack
   cli:
     service:
       create:
@@ -277,7 +279,7 @@ docker:
     dashboard:
       image: {{ site.img_dashboard }}
       version: {{ site.ver_dashboard }}
-      container_name: dashboard
+      container_name: osdsDash
       privileged: True
       network_mode: host
       deploy:

--- a/pillar.example
+++ b/pillar.example
@@ -15,6 +15,8 @@ mysql:
 etcd:
   #service:
     #etcd_endpoints: https://{{ site.host_ipv4 or site.host_ipv6 }}:2379,https://{{ site.host_ipv4 or site.host_ipv6 }}:2380
+  dir:
+    tmp: /tmp/devstack  {# not sure why centos wants this here? #}
   docker:
     image: {{ site.img_etcd }}
     version: {{ site.ver_etcd }}

--- a/site.j2
+++ b/site.j2
@@ -39,10 +39,10 @@
       'devstack_password': 'opensds@123',
       'devstack_dir': '/opt/opensds-linux-amd64-devstack',
 
-      'host_ipv4': grains.ipv4[1],
-      'host_ipv6': grains.ipv6[1],
-      'tgtBindIp': grains.ipv4[1],
-      'db_host': grains.ipv4[1],
+      'host_ipv4': grains.ipv4[2],
+      'host_ipv6': grains.ipv6[2],
+      'tgtBindIp': grains.ipv4[2],
+      'db_host': grains.ipv4[2],
 
       'port_controller': '50040',
       'port_dock': '50050',

--- a/site.j2
+++ b/site.j2
@@ -39,9 +39,11 @@
       'devstack_password': 'opensds@123',
       'devstack_dir': '/opt/opensds-linux-amd64-devstack',
 
-      'host_ipv4': grains.ipv4[-1],
-      'host_ipv6': grains.ipv6[-1],
-      'db_host': '127.0.0.1',
+      'host_ipv4': grains.ipv4[1],
+      'host_ipv6': grains.ipv6[1],
+      'tgtBindIp': grains.ipv4[1],
+      'db_host': grains.ipv4[1],
+
       'port_controller': '50040',
       'port_dock': '50050',
 }) %}


### PR DESCRIPTION
The PR fixes three items-

Firstly a few more `replace:False` are needed to stop these-
```
[WARNING ] State for file: /etc/opensds/opensds.conf - Neither 'source' nor 'contents' nor 'contents_pillar' nor 'contents_grains' was defined, yet 'replace' was set to 'True'. As there is no source to replace the file with, 'replace' has been set to 'False' to avoid reading the file unnecessarily.
```

Secondly the `tgtBindIP` value should match site hostname.

Finally grains.ipv4[1] & ipv6[1] are probably better defaults for host ip address.