### PR TITLE
Fix multicloud systemd service

### DIFF
--- a/opensds/gelato/daemon/init.sls
+++ b/opensds/gelato/daemon/init.sls
@@ -97,9 +97,9 @@ opensds gelato daemon systemd {{ instance }} service started:
     - context:
         svc: {{ instance }}
         systemd: {{ opensds.systemd|json }}
-        start: {{ daemon.start }} {{ golang.go_path }}/src/github.com/opensds/{{ instance }}
+        start: {{ daemon.start }}
         stop: /usr/bin/killall opensds-{{ instance }}
-        workdir: /usr/local
+        workdir: {{ golang.go_path }}/src/github.com/opensds/{{ instance }}/
   cmd.run:
     - names:
       - systemctl daemon-reload

--- a/opensds/gelato/defaults.yaml
+++ b/opensds/gelato/defaults.yaml
@@ -22,7 +22,6 @@ opensds:
       multi-cloud:
         strategy: keystone-repo-systemd       #or keystone-release-systemd, or keystone-compose-system
         start: /usr/local/bin/docker-compose up -d
-        work: /usr/local/golang/packages/src/github.com/opensds/multi-cloud
         repo:
           url: https://github.com/opensds/multi-cloud.git
           branch: stable/bali


### PR DESCRIPTION
Forgot to set working directory.
```
root@ubuntu1804:/usr/lib/systemd/system# systemctl status opensds-multi-cloud
* opensds-multi-cloud.service - OpenSDS multi-cloud service
   Loaded: loaded (/usr/lib/systemd/system/opensds-multi-cloud.service; enabled; vendor preset: enabled)
   Active: failed (Result: exit-code) since Tue 2019-01-22 14:56:50 MST; 12min ago
     Docs: https://opensds.io
 Main PID: 555 (code=exited, status=1/FAILURE)

Jan 22 14:56:50 ubuntu1804.localdomain systemd[1]: Started OpenSDS multi-cloud service.
Jan 22 14:56:50 ubuntu1804.localdomain docker-compose[555]:         Can't find a suitable configuration file in this directory or any
Jan 22 14:56:50 ubuntu1804.localdomain docker-compose[555]:         parent. Are you in the right directory?
Jan 22 14:56:50 ubuntu1804.localdomain docker-compose[555]:         Supported filenames: docker-compose.yml, docker-compose.yaml
Jan 22 14:56:50 ubuntu1804.localdomain docker-compose[555]:         
Jan 22 14:56:50 ubuntu1804.localdomain systemd[1]: opensds-multi-cloud.service: Main process exited, code=exited, status=1/FAILURE
Jan 22 14:56:50 ubuntu1804.localdomain systemd[1]: opensds-multi-cloud.service: Failed with result 'exit-code'
```