### PR TITLE
Fix Dashboard container on CentOS

### DIFF
--- a/opensds/dashboard/config.sls
+++ b/opensds/dashboard/config.sls
@@ -4,6 +4,7 @@
 {% from "opensds/map.jinja" import opensds with context %}
 
 include:
+  - nginx.ng    ### ensure nginx filesystem config exists
   - opensds.config
 
 opensds dashboard config ensure apache dead:

--- a/opensds/dashboard/container/init.sls
+++ b/opensds/dashboard/container/init.sls
@@ -4,7 +4,7 @@
 {% from "opensds/map.jinja" import opensds, docker with context %}
 
 include:
-  - opensds.config
+  - opensds.dashboard.config
 
   {%- for instance in opensds.dashboard.instances %}
      {%- if instance in opensds.dashboard.container %}

--- a/pillar.example
+++ b/pillar.example
@@ -439,6 +439,9 @@ nginx:
     servers:
       managed:
         default:
+          {%- if grains.os_family in ('RedHat',) %}
+          available_dir: /etc/nginx/sites-available
+          {%- endif %}
           enabled: True
           overwrite: True
           config:
@@ -457,8 +460,6 @@ nginx:
                 - index.htm
           {%- if grains.os_family == 'Debian' %}
                 - index.nginx-debian.html
-          {%- elif grains.os_family in ('Redhat',) %}
-                - available_path: /etc/nginx/sites-available
           {%- endif %}
               - location /{{ site.hotpot_release }}/:
                 - proxy_pass: 'http://{{ site.host_ipv4 or site.host_ipv6 or "127.0.0.1"}}:{{ site.port_hotpot }}/{{ site.hotpot_release }}'


### PR DESCRIPTION
Resolves #38 and verified on CentOS7
```
          ID: opensds dashboard container dashboard running
    Function: docker_container.running
        Name: dashboard
      Result: True
     Comment: Container 'dashboard' is already configured as specified. State changed from 'stopped' to 'running'.
     Started: 17:49:21.556307
    Duration: 316.563 ms
     Changes:   
              ----------
              state:
                  ----------
                  new:
                      running
                  old:
                      stopped
```