### PR TITLE
Fixes for CentOS nuances

### DIFF
--- a/opensds/auth/config/clean.sls
+++ b/opensds/auth/config/clean.sls
@@ -11,7 +11,7 @@
             {%- if "opensdsconf" in opensds.auth and id in opensds.auth.opensdsconf %}
 
 {{ cleanup_config('opensds', 'auth config', id, opensds.conf)}}
-{{ cleanup_files('opensds', 'auth config', id, opensds.auth) }}
+{{ cleanup_files('opensds', 'auth config', id) }}
 
             {%- endif %}
         {%- endfor %}

--- a/opensds/backend/block/daemon/init.sls
+++ b/opensds/backend/block/daemon/init.sls
@@ -21,7 +21,7 @@ include:
           {%- if 'daemon' in opensds.backend.block and id in opensds.backend.block.daemon  %}
               {%- if opensds.backend.block.daemon[ id ] is mapping %}
 
-    {%- if grains.os in ('CentOS', ) %}
+    {%- if id == 'cinder' and  grains.os in ('CentOS', ) %}
 opensds infra use git2 on EL:
   pkg.installed:
     - sources:
@@ -30,7 +30,7 @@ opensds infra use git2 on EL:
     - name: yum swap git git2u -y
   {%- endif %}
 
-{{ workflow('opensds', 'backend block daemon', id, opensds.backend.block, opensds.dir.sushi, opensds) }}
+{{ workflow('opensds', 'backend block daemon', id, opensds.backend.block, opensds.dir.sushi, opensds, golang) }}
 
               {%- endif %}
           {%- endif %}

--- a/opensds/backend/block/daemon/init.sls
+++ b/opensds/backend/block/daemon/init.sls
@@ -21,7 +21,16 @@ include:
           {%- if 'daemon' in opensds.backend.block and id in opensds.backend.block.daemon  %}
               {%- if opensds.backend.block.daemon[ id ] is mapping %}
 
-{{ workflow('opensds', 'backend block daemon', id, opensds.backend.block, opensds.dir.sushi, opensds.systemd) }}
+    {%- if grains.os in ('CentOS', ) %}
+opensds infra use git2 on EL:
+  pkg.installed:
+    - sources:
+      - ius-release: https://centos7.iuscommunity.org/ius-release.rpm
+  cmd.run:
+    - name: yum swap git git2u -y
+  {%- endif %}
+
+{{ workflow('opensds', 'backend block daemon', id, opensds.backend.block, opensds.dir.sushi, opensds) }}
 
               {%- endif %}
           {%- endif %}

--- a/opensds/backend/config/clean.sls
+++ b/opensds/backend/config/clean.sls
@@ -5,14 +5,13 @@
 
     {%- if opensds.deploy_project not in ('gelato',) %}
 
-{%- from 'opensds/files/macros.j2' import cleanup_config, cleanup_files with context %}
+{%- from 'opensds/files/macros.j2' import cleanup_config with context %}
 {%- from "opensds/map.jinja" import golang, packages with context %}
 
         {%- for id in opensds.backend.ids %}
             {%- if "opensdsconf" in opensds.backend and id in opensds.backend.opensdsconf %}
 
 {{ cleanup_config('opensds', 'backend config', id, opensds.conf) }}
-{{ cleanup_files('opensds', 'backend', id, opensds.backend) }}
 
             {%- endif %}
         {%- endfor %}

--- a/opensds/dashboard/config/clean.sls
+++ b/opensds/dashboard/config/clean.sls
@@ -12,7 +12,7 @@
             {%- if "opensdsconf" in opensds.dashboard and id in opensds.dashboard.opensdsconf %}
 
 {{ cleanup_config('opensds', 'dashboard config', id, opensds.conf) }}
-{{ cleanup_files('opensds', 'dashboard config', id, opensds.dashboard) }}
+{{ cleanup_files('opensds', 'dashboard config', id, opensds.dir.dashboard) }}
 
             {%- endif %}
         {%- endfor %}

--- a/opensds/dashboard/daemon/init.sls
+++ b/opensds/dashboard/daemon/init.sls
@@ -35,7 +35,7 @@ opensds dashboard config install angular cli:
    - unless: {{ 'container' in opensds.dashboard.daemon[ id ]|lower }}
                     {%- endif %}
 
-{{ workflow('opensds', 'dashboard daemon', id, opensds.dashboard, opensds.dir.dashboard, opensds.systemd) }}
+{{ workflow('opensds', 'dashboard daemon', id, opensds.dashboard, opensds.dir.dashboard, opensds) }}
 
                 {%- endif %}
             {%- endif %}

--- a/opensds/dashboard/daemon/init.sls
+++ b/opensds/dashboard/daemon/init.sls
@@ -35,7 +35,7 @@ opensds dashboard config install angular cli:
    - unless: {{ 'container' in opensds.dashboard.daemon[ id ]|lower }}
                     {%- endif %}
 
-{{ workflow('opensds', 'dashboard daemon', id, opensds.dashboard, opensds.dir.dashboard, opensds) }}
+{{ workflow('opensds', 'dashboard daemon', id, opensds.dashboard, opensds.dir.dashboard, opensds, golang) }}
 
                 {%- endif %}
             {%- endif %}

--- a/opensds/database/config/clean.sls
+++ b/opensds/database/config/clean.sls
@@ -4,14 +4,13 @@
 {%- from "opensds/map.jinja" import opensds with context %}
 
     {%- if opensds.deploy_project not in ('gelato',) %}
-{%- from 'opensds/files/macros.j2' import cleanup_files, cleanup_config with context %}
+{%- from 'opensds/files/macros.j2' import cleanup_config with context %}
 {%- from "opensds/map.jinja" import golang, packages with context %}
 
         {%- for id in opensds.database.ids %}
             {%- if "opensdsconf" in opensds.database and id in opensds.database.opensdsconf %}
 
 {{ cleanup_config('opensds', 'database config', id, opensds.conf)}}
-{{ cleanup_files('opensds', 'database config', id, opensds.database) }}
 
             {%- endif %}
         {%- endfor %}

--- a/opensds/dock/config/clean.sls
+++ b/opensds/dock/config/clean.sls
@@ -12,7 +12,7 @@
             {%- if "opensdsconf" in opensds.dock and id in opensds.dock.opensdsconf %}
 
 {{ cleanup_config('opensds', 'dock config', id, opensds.conf)}}
-{{ cleanup_files('opensds', 'dock config', id, opensds.dock) }}
+{{ cleanup_files('opensds', 'dock config', id, None, ['osdsdock',]) }}
 
             {%- endif %}
         {%- endfor %}

--- a/opensds/dock/config/init.sls
+++ b/opensds/dock/config/init.sls
@@ -19,5 +19,6 @@ include:
                 {%- endif %}
             {%- endif %}
         {%- endfor %}
-{{ create_dir('opensds','dock config', id, opensds.dir.hotpot + '/volumegroups', opensds.user, opensds.mode) }}
+
+{{ create_dir('opensds','dock config', 'volumegroups', opensds.dir.hotpot) }}
     {%- endif %}

--- a/opensds/dock/config/init.sls
+++ b/opensds/dock/config/init.sls
@@ -19,5 +19,5 @@ include:
                 {%- endif %}
             {%- endif %}
         {%- endfor %}
-{{ create_dir('opensds','dock config', '', opensds.dir.hotpot + '/volumegroups') }}
+{{ create_dir('opensds','dock config', id, opensds.dir.hotpot + '/volumegroups', opensds.user, opensds.mode) }}
     {%- endif %}

--- a/opensds/dock/daemon/init.sls
+++ b/opensds/dock/daemon/init.sls
@@ -12,7 +12,7 @@ include:
       {%- for id in opensds.dock.ids %}
         {% if 'daemon' in opensds.dock and id in opensds.dock.daemon and opensds.dock.daemon[id] is mapping %}
 
-{{ workflow('opensds', 'dock daemon', id, opensds.dock, opensds.dir.hotpot, opensds.systemd) }}
+{{ workflow('opensds', 'dock daemon', id, opensds.dock, opensds.dir.hotpot, opensds) }}
 
         {%- endif %}
       {%- endfor %}

--- a/opensds/dock/daemon/init.sls
+++ b/opensds/dock/daemon/init.sls
@@ -12,7 +12,7 @@ include:
       {%- for id in opensds.dock.ids %}
         {% if 'daemon' in opensds.dock and id in opensds.dock.daemon and opensds.dock.daemon[id] is mapping %}
 
-{{ workflow('opensds', 'dock daemon', id, opensds.dock, opensds.dir.hotpot, opensds) }}
+{{ workflow('opensds', 'dock daemon', id, opensds.dock, opensds.dir.hotpot, opensds, golang) }}
 
         {%- endif %}
       {%- endfor %}

--- a/opensds/files/macros.j2
+++ b/opensds/files/macros.j2
@@ -4,7 +4,7 @@
 #---- - - -- --- ---
 #  installer workflow
 #-- - --- - -- -- --
-{%- macro workflow(name, tag, id, subsys, workdir, systemd, plugin_type=None) %}
+{%- macro workflow(name, tag, id, subsys, workdir, self, plugin_type=None) %}
      {%- if 'daemon' in subsys and id in subsys.daemon and subsys.daemon[id] is mapping %}
         {%- if 'repo' in subsys.daemon[id]['strategy']|lower %}
             {# you may want to expand this over time #}
@@ -25,7 +25,7 @@
 {{ cp_binaries(name, tag, id, subsys.daemon[id], subsys['binaries'], workdir, '/usr/local/bin') }}
         {%- endif %}
         {%- if 'systemd' in subsys.daemon[id]['strategy']|lower %}
-{{ service_run(name, tag, id, subsys.daemon[id], systemd, workdir, plugin_type) }}
+{{ service_run(name, tag, id, subsys.daemon[id], self, workdir, plugin_type) }}
         {%- endif %}
      {%- endif %}
 
@@ -34,7 +34,7 @@
 #- -- -- -- ---
 #  daemon clean
 #-- -- -  -- --
-{%- macro daemon_clean(name, tag, id, subsys, systemd, plugin_type=None) %}
+{%- macro daemon_clean(name, tag, id, subsys, self, plugin_type=None) %}
        {% if plugin_type and id|string != plugin_type|string %}
           {%- set daemon=None %}
        {%- endif %}
@@ -43,7 +43,7 @@
          {%- set daemon = subsys.daemon[ id ] %}
          {%- if daemon is mapping %}
              {%- if 'systemd' in daemon.strategy|lower %}
-{{ service_stopped(name, tag, id, daemon, systemd) }}
+{{ service_stopped(name, tag, id, daemon, self) }}
              {%- endif %}
          {%- elif 'container' in daemon.strategy|lower %}
 {{ container_stopped(name, tag, id, subsys.container) }}
@@ -51,7 +51,7 @@
      {%- elif 'container' in daemon.strategy|lower and 'container' in subsys %}
 {{ container_stopped(name, tag, id, subsys.container) }}
      {%- endif %}
-{{ cleanup_files(name, tag, id, subsys) }}
+{{ cleanup_files(name, tag, id) }}
 
 {%- endmacro %}
 
@@ -59,7 +59,7 @@
 #---- - - -- --- ---#
 #  create directory
 #-- --- --- - -- ---#
-{%- macro create_dir(name, tag, id, dir) %}
+{%- macro create_dir(name, tag, id, dir, user=None, mode=None) %}
 
             #############################
             #### create {{id}} directory
@@ -69,9 +69,9 @@
     - name: {{ dir }}/{{ id }}
     - force: True
     - makedirs: True
-    - user: {{ opensds.user or 'root' }}
-    - dir_mode: {{ opensds.dir_mode or '0755' }}
-    # recurse:     Comment out due to lsattr taking too long
+    - user: {{ user or 'root' }}
+    - dir_mode: {{ mode or '0755' }}
+    # recurse:     ##commented out due to lsattr taking too long
     # - user
     # - mode
 
@@ -80,7 +80,7 @@
 #-- -  - -  -- - - ---#
 #  Cleanup filesystem
 #-- -- -  --- - --  --#
-{%- macro cleanup_files(name, tag, id, dir, binaries=None) %}
+{%- macro cleanup_files(name, tag, id, dir=None, binaries=None) %}
 
             ################################
             #### cleanup {{id}} files
@@ -88,11 +88,10 @@
 {{ name }} {{ tag }} {{ id }} cleanup filesystem:
   file.absent:
     - names:
-      - {{ opensds.dir.hotpot }}/{{ id }}
-      - {{ opensds.dir.sushi }}/{{ id }}
-      - {{ opensds.dir.hotpot }}/{{ id }}
-      - {{ opensds.dir.sushi }}/{{ id }}
       - /usr/local/golang/packages/src/github.com/opensds/{{ id }}
+            {%- if dir %}
+      - {{ dir }}
+            {%- endif %}
          {%- if binaries and binaries is iterable %}
              {%- for b in binaries[id] %}
       - {{ dir }}/{{ b }}
@@ -182,7 +181,7 @@
     - target: {{ dir }}/{{ id }}
     - rev: {{ 'master' if not 'branch' in daemon.repo else daemon.repo.branch }}
     - force_checkout: True
-    - force_clone: {{ opensds.force_clone }}
+    - force_clone: True
     - force_fetch: True
     - force_reset: True
     - retry:
@@ -197,7 +196,7 @@
 #-- -  - -  -- - - - --#
 #  Run Systemd service #
 #-- ---- -  -- - - - --#
-{%- macro service_run(name, tag, id, daemon, systemd, dir, plugin_type=None) %}
+{%- macro service_run(name, tag, id, daemon, self, dir, plugin_type=None) %}
        {% if plugin_type and id|string != plugin_type|string %}
           {%- set daemon=None %}
        {%- endif %}
@@ -209,27 +208,27 @@
             ######################
 {{ name }} {{ tag }} {{ id }} systemd started:
   file.managed:
-    - name: {{ systemd.dir + '/' + name + '-' + id + '.service' }}
+    - name: {{ self.systemd.dir + '/' + name + '-' + id + '.service' }}
     - source: salt://{{ name }}/files/daemon.j2
     - mode: '0644'
     - template: jinja
     - makedirs: True
     - context:
       svc: {{ id }}
-      environ: {{ opensds.environ }}
-      systemd: {{ systemd|json }}
+      environ: {{ self.environ }}
+      systemd: {{ self.systemd|json }}
          {%- if "compose" in daemon.strategy|lower %}
-      start: {{ opensds.compose }} up
-      stop: {{ opensds.compose }} down
+      start: {{ self.compose }} up
+      stop: {{ self.compose }} down
          {%- else %}
       start: {{ daemon.start }}
       stop: {{ daemon.stop }}
          {%- endif %}
          {%- if id|lower in ('provisioner',) %}
          ##### workaround https://github.com/opensds/opensds-installer/issues/110
-      workdir: {{ opensds.dir.sushi }}/nbp/{{ id }}
+      workdir: {{ self.dir.sushi }}/nbp/{{ id }}
          {%- elif id|lower in ('cinder',) %}
-      workdir: {{ opensds.dir.sushi }}/{{ id }}/{{ daemon.repo.build_subdir }}
+      workdir: {{ self.dir.sushi }}/{{ id }}/{{ daemon.repo.build_subdir }}
          {%- elif 'repo' in daemon and daemon.repo is mapping and 'binaries_subdir' in daemon.repo and daemon.repo.binaries_subdir %}
       workdir: {{ dir }}/{{ '' if not plugin_type else plugin_type }}/{{ 'opensds' if id == 'osdsdock' else id }}/{{ daemon.repo.binaries_subdir }}
          {%- else %}
@@ -255,7 +254,7 @@
 #--- - - --- -- - - -- -#
 #  stop systemd service #
 #--- ---- --- -- - - ---#
-{%- macro service_stopped(name, tag, id, daemon, systemd) %}
+{%- macro service_stopped(name, tag, id, daemon, self) %}
        {%- if "systemd" in daemon.strategy|lower and daemon is mapping %}
 
             ######################
@@ -265,7 +264,7 @@
   service.dead:
     - name: {{ name }}-{{ id }}
   file.absent:
-    - name: {{ systemd.dir }}/{{ name }}-{{ id }}.daemon
+    - name: {{ self.systemd.dir }}/{{ name }}-{{ id }}.daemon
     - watch:
       - service: {{ name }} {{ tag }} {{ id }} systemd service stopped
   cmd.run:
@@ -364,8 +363,8 @@
 #-- - - - - - - - ---- -- - - --#
 #  Copy binary from dir to dest
 #--- -- -- - - -  --- - ---- - -#
-{%- macro cp_binaries(name, tag, id, daemon, binaries, dir=opensds.dir.go, dest=opensds.dir.hotpot) %}
-    {%- if id in binaries and binaries[id] is iterable %}
+{%- macro cp_binaries(name, tag, id, daemon, binaries, dir=None, dest=None) %}
+    {%- if dir and dest and id in binaries and binaries[id] is iterable %}
 
            ######################################
            #### Copy binaries to /usr/local/bin 
@@ -400,8 +399,8 @@
 #-- -- - -- - - - - -#
 #  Build from source #
 #- - - - -- ---- - --#
-{%- macro build_source(name, tag, id, daemon, dir=opensds.dir.go) %}
-  {%- if daemon and 'build' in daemon.strategy|lower and 'repo' in daemon and daemon.repo is mapping %}
+{%- macro build_source(name, tag, id, daemon, dir=None) %}
+  {%- if dir and daemon and 'build' in daemon.strategy|lower and 'repo' in daemon and daemon.repo is mapping %}
       {%- if "build_cmd" in daemon.repo %}
 
             ###################

--- a/opensds/files/macros.j2
+++ b/opensds/files/macros.j2
@@ -4,16 +4,16 @@
 #---- - - -- --- ---
 #  installer workflow
 #-- - --- - -- -- --
-{%- macro workflow(name, tag, id, subsys, workdir, self, plugin_type=None) %}
+{%- macro workflow(name, tag, id, subsys, workdir, self, golang, plugin_type=None) %}
      {%- if 'daemon' in subsys and id in subsys.daemon and subsys.daemon[id] is mapping %}
         {%- if 'repo' in subsys.daemon[id]['strategy']|lower %}
             {# you may want to expand this over time #}
             {%- if  id not in ('cinder',) %}
-                {%- set workdir = golang.go_path+'/src/github.com/opensds' %}
+                {%- set workdir = golang.go_path + '/src/github.com/opensds' %}
             {%- endif %}
         {%- endif %}
         {%- if 'build' in subsys.daemon[id]['strategy']|lower %}
-{{ build_source(name, tag, id, subsys.daemon[id], workdir) }}
+{{ build_source(name, tag, id, subsys.daemon[id], golang, workdir) }}
         {%- endif %}
      {%- endif %}
      {%- if 'container' in subsys.daemon[id]['strategy'] and 'container' in subsys %}
@@ -59,18 +59,18 @@
 #---- - - -- --- ---#
 #  create directory
 #-- --- --- - -- ---#
-{%- macro create_dir(name, tag, id, dir, user=None, mode=None) %}
+{%- macro create_dir(name, tag, id, dir, user='root', mode='0755') %}
 
             #############################
             #### create {{id}} directory
             #############################
-{{ name }} {{ tag }} {{ id }} ensure directory {{ dir }} exists:
+{{ name }} {{ tag }} {{ id }} ensure directory {{ dir }}/{{ id }} exists:
   file.directory:
     - name: {{ dir }}/{{ id }}
     - force: True
     - makedirs: True
-    - user: {{ user or 'root' }}
-    - dir_mode: {{ mode or '0755' }}
+    - user: {{ user }}
+    - dir_mode: {{ mode }}
     # recurse:     ##commented out due to lsattr taking too long
     # - user
     # - mode
@@ -399,7 +399,7 @@
 #-- -- - -- - - - - -#
 #  Build from source #
 #- - - - -- ---- - --#
-{%- macro build_source(name, tag, id, daemon, dir=None) %}
+{%- macro build_source(name, tag, id, daemon, golang, dir=None) %}
   {%- if dir and daemon and 'build' in daemon.strategy|lower and 'repo' in daemon and daemon.repo is mapping %}
       {%- if "build_cmd" in daemon.repo %}
 

--- a/opensds/gelato/config/clean.sls
+++ b/opensds/gelato/config/clean.sls
@@ -12,7 +12,7 @@
             {%- if "opensdsconf" in opensds.gelato and id in opensds.gelato.opensdsconf %}
 
 {{ cleanup_config('opensds', 'gelato config', id, opensds.conf)}}
-{{ cleanup_files('opensds', 'gelato config', id, opensds.gelato) }}
+{{ cleanup_files('opensds', 'gelato config', id, opensds.dir.gelato) }}
 
             {%- endif %}
         {%- endfor %}

--- a/opensds/gelato/daemon/init.sls
+++ b/opensds/gelato/daemon/init.sls
@@ -17,7 +17,7 @@ include:
            {%- if 'daemon' in opensds.gelato and id in opensds.gelato.daemon %}
                {%- if opensds.gelato.daemon[ id ] is mapping %}
 
-{{ workflow('opensds', 'gelato daemon', id, opensds.gelato, opensds.dir.gelato, opensds.systemd) }}
+{{ workflow('opensds', 'gelato daemon', id, opensds.gelato, opensds.dir.gelato, opensds) }}
 
                {%- endif %}
            {%- endif %}

--- a/opensds/gelato/daemon/init.sls
+++ b/opensds/gelato/daemon/init.sls
@@ -17,7 +17,14 @@ include:
            {%- if 'daemon' in opensds.gelato and id in opensds.gelato.daemon %}
                {%- if opensds.gelato.daemon[ id ] is mapping %}
 
-{{ workflow('opensds', 'gelato daemon', id, opensds.gelato, opensds.dir.gelato, opensds) }}
+               {%- if id == 'multi-cloud' and grains.os_family in ('RedHat',) %}
+opensds gelato daemon {{ id }} workaround Failed-to-program-FILTER-chain:
+  cmd.run:
+    - name: systemctl restart docker
+               {%- endif %}
+
+
+{{ workflow('opensds', 'gelato daemon', id, opensds.gelato, opensds.dir.gelato, opensds, golang) }}
 
                {%- endif %}
            {%- endif %}

--- a/opensds/hotpot/config/clean.sls
+++ b/opensds/hotpot/config/clean.sls
@@ -12,7 +12,7 @@
             {%- if "opensdsconf" in opensds.hotpot and id in opensds.hotpot.opensdsconf and opensds.hotpot.opensdsconf[id] is mapping %}
 
 {{ cleanup_config('opensds', 'hotpot config', id, opensds.conf) }}
-{{ cleanup_files('opensds', 'hotpot config', id, opensds.hotpot) }}
+{{ cleanup_files('opensds', 'hotpot config', id, opensds.dir.hotpot) }}
 
             {%- endif %}
         {%- endfor %}

--- a/opensds/hotpot/daemon/init.sls
+++ b/opensds/hotpot/daemon/init.sls
@@ -15,7 +15,7 @@ include:
     {%- for id in opensds.hotpot.ids %}
       {% if 'daemon' in opensds.hotpot and id in opensds.hotpot.daemon and opensds.hotpot.daemon[id] is mapping %}
 
-{{ workflow('opensds', 'hotpot daemon', id, opensds.hotpot, opensds.dir.hotpot, opensds) }}
+{{ workflow('opensds', 'hotpot daemon', id, opensds.hotpot, opensds.dir.hotpot, opensds, golang) }}
 
             {%- endif %}
         {%- endfor %}

--- a/opensds/hotpot/daemon/init.sls
+++ b/opensds/hotpot/daemon/init.sls
@@ -15,7 +15,7 @@ include:
     {%- for id in opensds.hotpot.ids %}
       {% if 'daemon' in opensds.hotpot and id in opensds.hotpot.daemon and opensds.hotpot.daemon[id] is mapping %}
 
-{{ workflow('opensds', 'hotpot daemon', id, opensds.hotpot, opensds.dir.hotpot, opensds.systemd) }}
+{{ workflow('opensds', 'hotpot daemon', id, opensds.hotpot, opensds.dir.hotpot, opensds) }}
 
             {%- endif %}
         {%- endfor %}

--- a/opensds/infra/init.sls
+++ b/opensds/infra/init.sls
@@ -24,12 +24,3 @@ opensds infra pkgs install {{ p }}:
     - name: {{ p }}
         {%- endfor %}
     {%- endif %}
-
-    {%- if grains.os in ('CentOS', ) %}
-opensds infra use git2 on EL:
-  pkg.installed:
-    - sources:
-      - ius-release: https://centos7.iuscommunity.org/ius-release.rpm
-  cmd.run:
-    - name: yum swap git git2u -y
-  {%- endif %}

--- a/opensds/sushi/plugin/daemon/init.sls
+++ b/opensds/sushi/plugin/daemon/init.sls
@@ -13,7 +13,7 @@
             {%- if 'daemon' in opensds.sushi.plugin and id in opensds.sushi.plugin.daemon  %}
                 {%- if opensds.sushi.plugin.daemon[id] is mapping %}
 
-{{ workflow('opensds','sushi plugin daemon', id, opensds.sushi.plugin, opensds.dir.sushi+'/nbp', opensds, opensds.sushi.plugin_type|string)}}
+{{ workflow('opensds','sushi plugin daemon', id, opensds.sushi.plugin, opensds.dir.sushi+'/nbp', opensds, golang, opensds.sushi.plugin_type|string)}}
 
                 {%- endif %}
             {%- endif %}

--- a/opensds/sushi/plugin/daemon/init.sls
+++ b/opensds/sushi/plugin/daemon/init.sls
@@ -13,7 +13,7 @@
             {%- if 'daemon' in opensds.sushi.plugin and id in opensds.sushi.plugin.daemon  %}
                 {%- if opensds.sushi.plugin.daemon[id] is mapping %}
 
-{{ workflow('opensds','sushi plugin daemon', id, opensds.sushi.plugin, opensds.dir.sushi+'/nbp', opensds.systemd, opensds.sushi.plugin_type|string)}}
+{{ workflow('opensds','sushi plugin daemon', id, opensds.sushi.plugin, opensds.dir.sushi+'/nbp', opensds, opensds.sushi.plugin_type|string)}}
 
                 {%- endif %}
             {%- endif %}

--- a/opensds/yaml/osfamilymap.yaml
+++ b/opensds/yaml/osfamilymap.yaml
@@ -45,6 +45,7 @@ RedHat:
     - nodejs
     - npm
     - libffi-devel 
+    - bind-utils
     # https://centos7.iuscommunity.org/ius-release.rpm
   backend:
     block:


### PR DESCRIPTION
This PR has some fixes verified on CentOS
- moves `git2` workaround to backend - otherwise devstack `stack.sh` fails.
- Fixes " Jinja error: global name 'l_opensds' is not defined" error
- Restarts docker to combat #37 and moby/moby#15948

Useful
- installs `bind-utils`