### PR TITLE
Skip ceph.repo state on Suse

### DIFF
--- a/opensds/backend/block/init.sls
+++ b/opensds/backend/block/init.sls
@@ -6,7 +6,9 @@
    {%- if opensds.deploy_project not in ('gelato',)  %}
 
 include:
+      {%- if grains.os_family not in ('Suse',) %}
   - ceph.repo
+      {%- endif %}
   - lvm.install
   - lvm.files.create
   - lvm.pv.create

--- a/opensds/yaml/osfamilymap.yaml
+++ b/opensds/yaml/osfamilymap.yaml
@@ -58,8 +58,8 @@ Suse:
   pkgs:
     - python3-pip
     - librados2
-    - librados2-devel
-    - librbd1
+    - librados-devel
+    - librbd-devel
     - gcc
     - make
     - docker-compose


### PR DESCRIPTION
Resolves #75 and #77  - verified on Suse.

```
opensuse-leap-x64:~/opensds-installer/salt # vi site.j2
opensuse-leap-x64:~/opensds-installer/salt # vi install.sh
opensuse-leap-x64:~/opensds-installer/salt # ./install.sh -i salt; ./install.sh -i opensds
Loading repository data...
Reading installed packages...

The following 5 items are locked and will not be changed by any action:
 Available:
  bash-completion snapper snapper-zypp-plugin virtualbox-guest-kmp-default virtualbox-guest-tools

Nothing to do.
Loading repository data...
Reading installed packages...
'wget' is already installed.
No update candidate for 'wget-1.19.5-lp150.2.3.1.x86_64'. The highest available version is already installed.
Resolving package dependencies...

Nothing to do.
--2019-02-21 12:52:19--  https://bootstrap.saltstack.com/
Resolving bootstrap.saltstack.com (bootstrap.saltstack.com)... 138.197.226.47, 2604:a880:400:d0::2:e001
Connecting to bootstrap.saltstack.com (bootstrap.saltstack.com)|138.197.226.47|:443... connected.
.... etc ....

run salt ...
local:
    ----------
    base:
        - salt.minion
        - salt.master
        - salt.formulas
        - salt.ssh
 ... this takes a while ... please be patient ...

Summary for local
-------------
Succeeded: 31 (changed=22)
Failed:     0
-------------
Total states run:     31
Total run time:   62.087 s
See full log in [ /tmp/opensds-installer-salt/install-salt/log.201902211252 ]

Accepted Keys:
opensuse-leap-x64
Denied Keys:
Unaccepted Keys:
Rejected Keys:
using [nginx] fixes branch
using [iscsi] fixes branch
using [docker] fixes branch
using [etcd] fixes branch
using [opensds] fixes branch
run salt ...
local:
    ----------
    base:
        - opensds.infra
 ... this takes a while ... please be patient ...

Summary for local
-------------
Succeeded: 83 (changed=20)
Failed:     0
-------------
Total states run:     83
Total run time:   55.062 s
See full log in [ /tmp/opensds-installer-salt/install-infra/log.201902211254 ]

run salt ...
local:
    ----------
    base:
        - opensds.keystone
 ... this takes a while ... please be patient ...

Summary for local
-------------
Succeeded: 24 (changed=10)
Failed:     0
-------------
Total states run:     24
Total run time:  582.516 s
See full log in [ /tmp/opensds-installer-salt/install-keystone/log.201902211255 ]

Services are running under systemd unit files.
For more information see: 
https://docs.openstack.org/devstack/latest/systemd.html

DevStack Version: stein
Change: f22c497c237c5f71437e5c9c0ed0811d005f0f4d Remove fedora-latest nodeset from Rocky 2019-02-04 16:46:20 +1100
OS Version: openSUSE 15.0 n/a

See full log in [ /tmp/devstack/stack.sh.log ]

run salt ...
local:
    ----------
    base:
        - opensds.config
 ... this takes a while ... please be patient ...

Summary for local
-------------
Succeeded: 15 (changed=10)
Failed:     0
-------------
Total states run:     15
Total run time:  390.923 ms
See full log in [ /tmp/opensds-installer-salt/install-config/log.201902211305 ]

run salt ...
local:
    ----------
    base:
        - opensds.database
 ... this takes a while ... please be patient ...

Summary for local
-------------
Succeeded: 33 (changed=15)
Failed:     0
-------------
Total states run:     33
Total run time:   60.786 s
See full log in [ /tmp/opensds-installer-salt/install-database/log.201902211305 ]

run salt ...
local:
    ----------
    base:
        - opensds.auth
 ... this takes a while ... please be patient ...

Summary for local
-------------
Succeeded: 41 (changed=18)
Failed:     0
-------------
Total states run:     41
Total run time:   24.252 s
See full log in [ /tmp/opensds-installer-salt/install-auth/log.201902211307 ]

run salt ...
local:
    ----------
    base:
        - opensds.hotpot
 ... this takes a while ... please be patient ...

Summary for local
-------------
Succeeded: 30 (changed=14)
Failed:     0
-------------
Total states run:     30
Total run time:  324.824 s
See full log in [ /tmp/opensds-installer-salt/install-hotpot/log.201902211307 ]

run salt ...
local:
    ----------
    base:
        - opensds.sushi
 ... this takes a while ... please be patient ...

Summary for local
-------------
Succeeded: 60 (changed=37)
Failed:     0
-------------
Total states run:     60
Total run time:  561.968 s
See full log in [ /tmp/opensds-installer-salt/install-sushi/log.201902211313 ]

run salt ...
local:
    ----------
    base:
        - opensds.backend
 ... this takes a while ... please be patient ...

Summary for local
-------------
Succeeded: 83 (changed=54)
Failed:     1
-------------
Total states run:     84
Total run time: 1154.499 s
See full log in [ /tmp/opensds-installer-salt/install-backend/log.201902211323 ]

run salt ...
local:
    ----------
    base:
        - opensds.dock
 ... this takes a while ... please be patient ...

Summary for local
-------------
Succeeded: 30 (changed=14)
Failed:     0
-------------
Total states run:     30
Total run time:    1.073 s
See full log in [ /tmp/opensds-installer-salt/install-dock/log.201902211343 ]

run salt ...
local:
    ----------
    base:
        - opensds.dashboard
 ... this takes a while ... please be patient ...

Summary for local
-------------
Succeeded: 21 (changed=5)
Failed:     0
-------------
Total states run:     21
Total run time:   47.614 s
See full log in [ /tmp/opensds-installer-salt/install-dashboard/log.201902211343 ]

run salt ...
local:
    ----------
    base:
        - opensds.gelato
 ... this takes a while ... please be patient ...

Summary for local
-------------
Succeeded: 42 (changed=20)
Failed:     0
-------------
Total states run:     42
Total run time:  284.863 s
See full log in [ /tmp/opensds-installer-salt/install-gelato/log.201902211344 ]

local:
    ----------
    opensds:
        - default
Copy opensds-installer/conf/policy.json to /etc/opensds/
```