### PR TITLE
Skip keystone if authentication is not keystone

### DIFF
--- a/opensds/gelato/daemon/init.sls
+++ b/opensds/gelato/daemon/init.sls
@@ -11,7 +11,16 @@
 
 include:
   - opensds.gelato.config
+        {%- if "keystone" in opensds.hotpot.opensdsconf.osdslet.auth_strategy|lower %}
+
   - devstack.cli
+        {%- else %}
+
+opensds gelato daemon init skipping keystone:
+  test.show_notification:
+    - text: |
+        Skipping keystone because `auth_strategy: noauth` (or something else) was configured!
+        {%- endif %}
 
         {%- for id in opensds.gelato.ids %}
            {%- if 'daemon' in opensds.gelato and id in opensds.gelato.daemon %}

--- a/opensds/keystone/init.sls
+++ b/opensds/keystone/init.sls
@@ -1,6 +1,9 @@
 ###  opensds/keystone/init.sls
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
+{%- from "opensds/map.jinja" import opensds with context %}
+
+{%- if "keystone" in opensds.hotpot.opensdsconf.osdslet.auth_strategy|lower %}
 
 include:
   - devstack.user
@@ -10,3 +13,12 @@ include:
   - devstack.install       {# workaround https://github.com/saltstack-formulas/devstack-formula/issues/13 #}
   {%- endif %}
   - opensds.keystone.conflicts.clean
+
+{%- else %}
+
+opensds keystone init nothing to do:
+  test.show_notification:
+    - text: |
+        Skipping keystone because `auth_strategy: noauth` (or something else) was configured!
+
+{%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -236,29 +236,29 @@ lvm:
     create:
       ### dd: copy a file, converting and formatting according to the operands
       dd:
-        {{ site.hotpot_path }}/volumegroups/{{ site.lvm_poolname }}.img:
+        {{ site.hotpot_path }}/volumegroups/{{ site.lvm_poolname }}.img:      #10G
           options:
             if: /dev/urandom
-            bs: 1024
-            count: 204800
+            bs: 1048576
+            count: 10240
 
       ### or truncate: Shrink or extend the size of each FILE to the specified size
       truncate:
         {{ site.hotpot_path }}/volumegroups/{{ site.cinder_poolname }}.img:
           options:
-            size: 100M
+            size: 1G
       'truncate ':
         {{ site.hotpot_path }}/volumegroups/{{ site.ceph_poolname }}.img:
           options:
-            size: 10M
+            size: 1G
       'truncate  ':
         {{ site.hotpot_path }}/volumegroups/{{ site.dorado_poolname }}.img:
           options:
-            size: 10M
+            size: 1G
       'truncate   ':
         {{ site.hotpot_path }}/volumegroups/{{ site.fusionstorage_poolname }}.img:
           options:
-            size: 10M
+            size: 1GM
 
       ### setup backing devices
       losetup:


### PR DESCRIPTION
This PR saves time by not running `devstack` states when authentication method is not "keystone".   Tested on CentOS.

& Updated sizes of lvm backing-files in` pillar.example`.