### PR TITLE
fix(nginx): fix breaking change in upstream nginx-formula

### DIFF
--- a/opensds/infra/init.sls
+++ b/opensds/infra/init.sls
@@ -17,6 +17,7 @@ include:
   - apache      ### manages port 80
   - nginx       ### manages port 8088 (daemon or container)
 
+
     {%- if opensds.pkgs and opensds.pkgs is iterable and opensds.pkgs is not string %}
         {%- for p in opensds.pkgs %}
 opensds infra pkgs install {{ p }}:

--- a/pillar.example
+++ b/pillar.example
@@ -534,36 +534,35 @@ resolver:
     - attempts:5
 
 nginx:
-  ng:
-    servers:
-      managed:
-        default:
-              {%- if grains.os_family in ('RedHat', 'Debian',) %}
-          available_dir: /etc/nginx/sites-available
-          enabled_dir: /etc/nginx/sites-available
-              {%- endif %}
-          enabled: True
-          overwrite: True
-          config:
-            - server:
-              - root:
-                - /var/www/html
-              - server_name: '_'
-              - listen:
-                - '8088 default_server'
-              - listen:
-                - '[::]:8088 default_server'
-          {%- if grains.os_family == 'Debian' %}
-              - index: 'index.html index.htm index.nginx-debian.html'
-          {%- else %}
-              - index: 'index.html index.htm'
-          {%- endif %}
-              - location /{{ site.hotpot_release }}/:
-                - proxy_pass: 'http://{{ site.host_ipv4 or site.host_ipv6 or "127.0.0.1"}}:{{ site.port_hotpot }}/{{ site.hotpot_release }}'
-              - location /v3/:
-                - proxy_pass: 'http://{{ site.host_ipv4 or site.host_ipv6 or "127.0.0.1"}}/identity/v3/'
-              - location /v1beta/:
-                - proxy_pass: 'http://{{ site.host_ipv4 or site.host_ipv6 or "127.0.0.1"}}:{{ site.port_hotpot }}/{{ site.hotpot_release }}/'
+  servers:
+    managed:
+      default:
+            {%- if grains.os_family in ('RedHat', 'Debian',) %}
+        available_dir: /etc/nginx/sites-available
+        enabled_dir: /etc/nginx/sites-available
+            {%- endif %}
+        enabled: True
+        overwrite: True
+        config:
+          - server:
+            - root:
+              - /var/www/html
+            - server_name: '_'
+            - listen:
+              - '8088 default_server'
+            - listen:
+              - '[::]:8088 default_server'
+        {%- if grains.os_family == 'Debian' %}
+            - index: 'index.html index.htm index.nginx-debian.html'
+        {%- else %}
+            - index: 'index.html index.htm'
+        {%- endif %}
+            - location /{{ site.hotpot_release }}/:
+              - proxy_pass: 'http://{{ site.host_ipv4 or site.host_ipv6 or "127.0.0.1"}}:{{ site.port_hotpot }}/{{ site.hotpot_release }}'
+            - location /v3/:
+              - proxy_pass: 'http://{{ site.host_ipv4 or site.host_ipv6 or "127.0.0.1"}}/identity/v3/'
+            - location /v1beta/:
+              - proxy_pass: 'http://{{ site.host_ipv4 or site.host_ipv6 or "127.0.0.1"}}:{{ site.port_hotpot }}/{{ site.hotpot_release }}/'
 
 memcached:
   daemonize: True


### PR DESCRIPTION
Fix this:
```
        ID: nginx-deprecated-in-v1.0.0-test-fail
    Function: test.fail_without_changes
        Name:

################################################################################
#                                                                              #
#                   WARNING: BREAKING CHANGES SINCE `v1.0.0`                   #
#                                                                              #
################################################################################
#                                                                              #
# Prior to `v1.0.0`, this formula provided two methods for managing NGINX; the #
# old method under `nginx` and the new method under `nginx.ng`. The old method #
# has now been removed and `nginx.ng` has been promoted to be `nginx` in its   #
# place.                                                                       #
#                                                                              #
# If you are not in a position to migrate, please pin your repo to the final   #
# release tag before `v1.0.0`, i.e. `v0.56.1`.                                 #
#                                                                              #
# To migrate from `nginx.ng`, simply modify your pillar to promote the entire  #
# section under `nginx:ng` so that it is under `nginx` instead. So with the    #
# editor of your choice, highlight the entire section and then unindent one    #
# level. Finish by removing the `ng:` line.                                    #
#                                                                              #
# To migrate from the old `nginx`, first convert to `nginx.ng` under `v0.56.1` #
# and then follow the steps laid out in the paragraph directly above.          #
#                                                                              #
################################################################################

      Result: False
     Comment: Failure!
     Started: 16:58:46.447882
    Duration: 0.566 ms
     Changes:
```