### PR TITLE
Non compat yaml renderer

### DIFF
--- a/opensds/config/init.sls
+++ b/opensds/config/init.sls
@@ -40,9 +40,9 @@ opensds config sdsrc file generated:
     - user: {{ opensds.user or 'root' }}
     - mode: {{ opensds.file_mode or '0644' }}
     - context:
-      golang: {{ golang }}
-      devstack: {{ devstack }}
-      opensds: {{ opensds }}
+      golang: {{ golang|json }}
+      devstack: {{ devstack|json }}
+      opensds: {{ opensds|json }}
 
 ### profile
 opensds infra system profile present:

--- a/opensds/dock/drivers/init.sls
+++ b/opensds/dock/drivers/init.sls
@@ -24,7 +24,7 @@ opensds backend driver {{ id }} generate driver file:
     - user: {{ opensds.user or 'root' }}
     - mode: {{ opensds.file_mode }}
     - context:
-      driver: {{ driver }}
+      driver: {{ driver|json }}
 
           {#- endif #}
       {%- endif %}

--- a/opensds/files/macros.j2
+++ b/opensds/files/macros.j2
@@ -43,13 +43,13 @@
          {%- set daemon = subsys.daemon[ id ] %}
          {%- if daemon is mapping %}
              {%- if 'systemd' in daemon.strategy|lower %}
-{{ service_stopped(name, tag, id, daemon, self) }}
+{{ service_stopped(name, tag, id, daemon, self|json) }}
              {%- endif %}
          {%- elif 'container' in daemon.strategy|lower %}
-{{ container_stopped(name, tag, id, subsys.container) }}
+{{ container_stopped(name, tag, id, subsys.container|json) }}
          {%- endif %}
      {%- elif 'container' in daemon.strategy|lower and 'container' in subsys %}
-{{ container_stopped(name, tag, id, subsys.container) }}
+{{ container_stopped(name, tag, id, subsys.container|json) }}
      {%- endif %}
 {{ cleanup_files(name, tag, id) }}
 
@@ -215,7 +215,7 @@
     - makedirs: True
     - context:
       svc: {{ id }}
-      environ: {{ self.environ }}
+      environ: {{ self.environ|json }}
       systemd: {{ self.systemd|json }}
          {%- if "compose" in daemon.strategy|lower %}
       start: {{ self.compose }} up
@@ -300,10 +300,10 @@
     - restart_policy: always
     - network_mode: host
            {%- if 'volumes' in container %}
-    - binds: {{ container.volumes }}
+    - binds: {{ container.volumes|json }}
            {%- endif %}
            {%- if 'ports' in container %}
-    - port_bindings: {{ container.ports }}
+    - port_bindings: {{ container.ports|json }}
            {%- endif %}
            {%- if 'env' in container %}
     - env:


### PR DESCRIPTION
Fix non-compatible yaml renderer impact.

Fixes this for example
```
[CRITICAL] Rendering SLS 'base:opensds.dashboard.daemon' failed: found unexpected ':'
```