### PR TITLE
fix(yaml): fix yaml to json to yaml conversion issue

### DIFF
--- a/opensds/dock/drivers/init.sls
+++ b/opensds/dock/drivers/init.sls
@@ -24,7 +24,7 @@ opensds backend driver {{ id }} generate driver file:
     - user: {{ opensds.user or 'root' }}
     - mode: {{ opensds.file_mode }}
     - context:
-      driver: {{ driver|json }}
+      driver: {{ driver }}
 
           {#- endif #}
       {%- endif %}

--- a/opensds/dock/drivers/yaml/template.jinja
+++ b/opensds/dock/drivers/yaml/template.jinja
@@ -1,21 +1,5 @@
-{%- macro section(outdict, spaces=0) -%}
-  {%- for key, value in outdict.items() -%}
-{{ block(key, value, spaces) }}
-  {%- endfor %}
-{%- endmacro -%}
+###################################################
+# File managed by Salt. Changes may be overwritten.
+###################################################
 
-{%- macro block(key, value, spaces=0) -%}
-  {%- set shift = spaces * ' ' -%}
-{%- if value is mapping %}
-{{shift}}{{ key }}{{ ':' -}}
-{{ section(value, spaces+2) }}
-{%- elif value is string or value is number %}
-{{ shift }}{{ key }}{{ ': ' }}{{ value -}}
-{%- elif value is iterable and value is not string %}
-{%- for v in value %}
-{{ shift }}{{ shift }}{{ v -}}
-{%- endfor %}
-{%- endif %}
-{%- endmacro -%}
-
-{{ section(driver) }}
+{{ driver|yaml(False) }}


### PR DESCRIPTION
This PR fixes a corner case error seen when converting yaml to json (see #97).
Yaml may have character sequences which JSON cannot interpret.

Issue & Fix verified on OpenSUSE
```
TypeError: '<' not supported between instances of 'str' and 'int'

; line 27

---
[...]
    - source: salt://opensds/dock/drivers/yaml/template.jinja
    - template: jinja
    - user: {{ opensds.user or 'root' }}
    - mode: {{ opensds.file_mode }}
    - context:
      driver: {{ driver|json }}    <======================

          {#- endif #}
      {%- endif %}
  {%- endfor %}
```