### PR TITLE
fix(archlinux): avoid rendering error

### DIFF
--- a/opensds/yaml/defaults.yaml
+++ b/opensds/yaml/defaults.yaml
@@ -49,3 +49,10 @@ opensds:
       LimitMEMLOCK: infinity
       TasksMax: infinity
       TasksAccounting: false
+
+  backend:
+    block:
+      container:
+        cinder:
+          makefile:
+            platform: 'debian:stretch'

--- a/opensds/yaml/osfamilymap.yaml
+++ b/opensds/yaml/osfamilymap.yaml
@@ -23,12 +23,6 @@ Debian:
     - libffi-dev
   systemd:
     dir: /usr/lib/systemd/system
-  backend:
-    block:
-      container:
-        cinder:
-          makefile:
-            platform: 'debian:stretch'
 
 RedHat:
   compose: /bin/docker-compose


### PR DESCRIPTION
Use `debian:stretch` as default for all OS (override in osfamily map).

Fixes this on Archlinux
```
SaltRenderError: Jinja variable 'dict object' has no attribute 'platform'
[CRITICAL] Rendering SLS 'base:opensds.backend.block.config.cinderbox' failed: Jinja variable 'dict object' has no attribute 'platform'
local:
    Data failed to compile:
----------
    Rendering SLS 'base:opensds.backend.block.config.cinderbox' failed: Jinja variable 'dict object' has no attribute 'platform'
Salt Version:
           Salt: 2019.2.0
```